### PR TITLE
Peter nguyen GitHub/settings auth navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,15 +19,17 @@ function App() {
         {/* <Navbar /> */}
         <SideMenu /> {/* Include the SideMenu component here */}
         <Routes>
-          <Route path="/" element={<Home />} />
+          {/* Authentication page will show initially when the app loads */}
+          <Route path="/" element={<Auth />} />
+          
+          {/* Other routes */}
+          <Route path="/home" element={<Home />} />
           <Route path="/loadingpage" element={<LoadingPage />} />
           <Route path="/favorites" element={<Favorites />} />
           <Route path="/history" element={<History />} />
           <Route path="/preferences" element={<Preferences />} />
           <Route path="/settings" element={<Settings />} />
-          <Route path="/login" element={<Auth />} />
           <Route path="/gpt" element={<Gpt />} />
-          {/* Add more routes here if needed */}
         </Routes>
       </Router>
     </div>

--- a/src/components/Authentication/Authentication.css
+++ b/src/components/Authentication/Authentication.css
@@ -53,3 +53,38 @@
 .auth-button:hover {
   background-color: #0f1d2e; /* Slightly darker on hover */
 }
+
+
+.welcome-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000; /* Ensure it appears above other content */
+  animation: fadeInOut 2s forwards; /* Animation to fade in and out */
+}
+
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  width: 300px;
+}
+
+@keyframes fadeInOut {
+  0% {
+  opacity: 0;
+  }
+  30% {
+  opacity: 1;
+  }
+  100% {
+  opacity: 0;
+  }
+}

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -90,19 +90,19 @@ function Home() {
         <Question
           defaultValue={budget}
           label="What's your budget?"
-          tooltipText="Budget Question Tooltip"
+          tooltipText="Budget determines the price range of the recipe and how much the generation can expect the user to have"
           onChange={setBudget}
         />
         <Question
           defaultValue={complexity}
           label="Cooking Complexity?"
-          tooltipText="Complexity Question Tooltip"
+          tooltipText="Complexity determines the difficulty of the recipe and how much prior cooking experience and knowledge the user has"
           onChange={setComplexity}
         />
         <Question
           defaultValue={time}
           label="Time Spent Cooking?"
-          tooltipText="Time Question Tooltip"
+          tooltipText="Time determines the length of the recipe and how much time the user has to spend cooking"
           onChange={setTime}
         />
 

--- a/src/components/Settings/Modal.css
+++ b/src/components/Settings/Modal.css
@@ -11,10 +11,12 @@
   }
   
   .modal-content {
-    background: white;
+    background: #ffffff;
+    border: 1px solid #c3dbdb;
+    border-radius: 10px;
     padding: 20px;
-    border-radius: 8px;
-    text-align: center;
+    margin-bottom: 15px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   }
   
   .modal-content input {
@@ -24,8 +26,23 @@
   }
   
   .modal-content button {
-    margin: 10px;
+    /*margin: 10px;*/
+    /*padding: 8px 12px;*/
+    background-color: #12263e; /* Dark blue */
+    color: #ffffff; /* White text */
+    border: none;
+    border-radius: 10px;
     padding: 8px 12px;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
+    width: 25%;
+    margin: 0 10px;
+  }
+  .button-group {
+    display: block;
+    text-align: center;
+    margin-top: 20px;
   }
   
   .error-message {

--- a/src/components/Settings/Modal.css
+++ b/src/components/Settings/Modal.css
@@ -28,3 +28,8 @@
     padding: 8px 12px;
   }
   
+  .error-message {
+    white-space: pre-wrap;
+    color: red;
+    margin-top: 10px;
+  }

--- a/src/components/Settings/Modal.js
+++ b/src/components/Settings/Modal.js
@@ -1,13 +1,73 @@
 import React, { useState } from "react";
+import { auth, db } from "../../configuration.js";
+import {updateEmail, updatePassword} from "firebase/auth";
+import {doc, setDoc, updateDoc } from "firebase/firestore";
 import "./Modal.css"; // Style this to look like a pop-up
 
-const Modal = ({ title, placeholder, onClose, onSave }) => {
+const Modal = ({ title, placeholder, onClose, onSave, currentField }) => {
 const [value, setValue] = useState("");
+const [error, setError] = useState("");
 
 
-const handleSave = () => {
-    onSave(value);
-    onClose();
+//validation functions for email and password
+const validateEmail = (email) => /\S+@\S+\.\S+/.test(email);
+const validatePassword = (password) => {
+    const minLength = 8;
+    const hasNumber = /\d/;
+    const hasSpecialChar = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
+    const hasUppercase = /[A-Z]/;
+    const hasLowercase = /[a-z]/;
+
+    return (
+        password.length >= minLength &&
+        hasNumber.test(password) &&
+        hasSpecialChar.test(password) &&
+        hasUppercase.test(password) &&
+        hasLowercase.test(password)
+    );
+};
+const validateUsername = (username) => {
+    return username.trim().length >= 3;
+}
+const handleSave = async () => {
+    try {
+        //resets error before validation
+        setError("");
+        if(currentField === "email") {
+            if (!validateEmail(value)) {
+                setError("Please enter a valid email address.");
+                return;
+            }
+
+            //update firebase authentication
+            await updateEmail(auth.currentUser, value);
+            const userDoc = doc(db, "users", auth.currentUser.uid);
+            //update firestore
+            await setDoc(userDoc, { email: value }, { merge: true });
+
+        } else if (currentField === "password") {
+            if (!validatePassword(value)) {
+                setError("Password must be at least 8 characters long, includewith at least one uppercase letter, one lowercase letter, contain at least one number, and one special character.");
+                return;
+            }
+
+            await updatePassword(auth.currentUser, value);
+        } else if (currentField === "username") {
+            if(!validateUsername(value)) {
+                setError("Username must be at least 3 characters long.");
+                return;
+            }
+
+            const userDoc = doc(db, "users", auth.currentUser.uid);
+            //updating firestore
+            await updateDoc(userDoc, { username: value });
+        }
+        onSave(value);
+        onClose();
+        } catch (err) {
+            //handle firebase errors
+            setError(err.message);
+        }
 };
 
 return (
@@ -15,16 +75,17 @@ return (
         <div className="modal-content">
             <h3>{title}</h3>
             <input 
-                type="text" 
+                type={currentField === "password" ? "password" : "text"}
                 placeholder={placeholder} 
                 value={value} 
                 onChange={(e) => setValue(e.target.value)} 
             />
+            {error && <p style={{ color: "red" }}>{error}</p>}
             <button onClick={handleSave}>Save</button>
             <button onClick={onClose}>Cancel</button>
     </div>
     </div>
-);
+    );
 };
 
 export default Modal;

--- a/src/components/Settings/Modal.js
+++ b/src/components/Settings/Modal.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { auth, db } from "../../configuration.js";
-import {updateEmail, updatePassword} from "firebase/auth";
+import {updateEmail, updatePassword, reauthenticateWithCredential, EmailAuthProvider} from "firebase/auth";
 import {doc, setDoc, updateDoc } from "firebase/firestore";
 import "./Modal.css"; // Style this to look like a pop-up
 
@@ -8,23 +8,35 @@ const Modal = ({ title, placeholder, onClose, onSave, currentField }) => {
 const [value, setValue] = useState("");
 const [error, setError] = useState("");
 
+const [oldPassword, setOldPassword] = useState("");
+const [newPassword, setNewPassword] = useState("");
+const [confirmPassword, setConfirmPassword] = useState("");
 
 //validation functions for email and password
 const validateEmail = (email) => /\S+@\S+\.\S+/.test(email);
 const validatePassword = (password) => {
+    const errors = [];
     const minLength = 8;
     const hasNumber = /\d/;
     const hasSpecialChar = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
     const hasUppercase = /[A-Z]/;
     const hasLowercase = /[a-z]/;
-
-    return (
-        password.length >= minLength &&
-        hasNumber.test(password) &&
-        hasSpecialChar.test(password) &&
-        hasUppercase.test(password) &&
-        hasLowercase.test(password)
-    );
+    if (password.length < minLength) {
+        errors.push(`at least ${minLength} characters long.`);
+    }
+    if (!hasNumber.test(password)) {
+        errors.push("include at least one number.");
+    }
+    if (!hasSpecialChar.test(password)) {
+        errors.push("include at least one special character.");
+    }
+    if (!hasUppercase.test(password)) {
+        errors.push("include at least one uppercase letter.");
+    }
+    if (!hasLowercase.test(password)) {
+        errors.push("include at least one lowercase letter.");
+    }
+    return errors;
 };
 const validateUsername = (username) => {
     return username.trim().length >= 3;
@@ -33,6 +45,7 @@ const handleSave = async () => {
     try {
         //resets error before validation
         setError("");
+        const user = auth.currentUser;
         if(currentField === "email") {
             if (!validateEmail(value)) {
                 setError("Please enter a valid email address.");
@@ -46,12 +59,36 @@ const handleSave = async () => {
             await setDoc(userDoc, { email: value }, { merge: true });
 
         } else if (currentField === "password") {
-            if (!validatePassword(value)) {
-                setError("Password must be at least 8 characters long, includewith at least one uppercase letter, one lowercase letter, contain at least one number, and one special character.");
+            if(newPassword !== confirmPassword) {
+                setError("Passwords do not match.");
                 return;
             }
-
-            await updatePassword(auth.currentUser, value);
+            //new password strength validation
+            const passwordErrors = validatePassword(newPassword);
+            if (passwordErrors.length > 0) {
+                const formattedErrors = "Password must be:\n" + passwordErrors.join("\n");
+                setError(formattedErrors);
+                return;
+                
+            }
+            try {
+                const credential = EmailAuthProvider.credential(user.email, oldPassword);
+                await reauthenticateWithCredential(user, credential);
+            } catch (err) {
+                if (err.code === "auth/wrong-password") {
+                    setError("The old password is incorrect.");
+                } else if (err.code === "auth/invalid-credential") {
+                    setError("The credentials provided are invalid. Please check your old password.");
+                } else {
+                    setError("An error occurred during reauthentication.");
+                }
+                return; // Stop execution if reauthentication fails
+            }
+            //update password
+            await updatePassword(user, newPassword);
+            //await updatePassword(auth.currentUser, value);
+            onSave("Password updated successfully");
+            onClose();
         } else if (currentField === "username") {
             if(!validateUsername(value)) {
                 setError("Username must be at least 3 characters long.");
@@ -74,16 +111,39 @@ return (
     <div className="modal-overlay">
         <div className="modal-content">
             <h3>{title}</h3>
+            {currentField === "password" ? (
+                <>
             <input 
-                type={currentField === "password" ? "password" : "text"}
-                placeholder={placeholder} 
-                value={value} 
-                onChange={(e) => setValue(e.target.value)} 
+                type="password" 
+                placeholder="Old Password"
+                value={oldPassword}
+                onChange={(e) => setOldPassword(e.target.value)}
             />
-            {error && <p style={{ color: "red" }}>{error}</p>}
+            <input
+                type="password"
+                placeholder="New Password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+            />
+            <input
+                type="password"
+                placeholder="Confirm Password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+            />
+            </>
+            ) : (
+                <input
+                    type={currentField === "email" ? "email" : "text"}
+                    placeholder={currentField === "email" ? "Enter new email" : "Enter new username"}
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                />
+            )}
+            {error && <p style={{ color: "red", whiteSpace: "pre-line" }}>{error}</p>}
             <button onClick={handleSave}>Save</button>
             <button onClick={onClose}>Cancel</button>
-    </div>
+        </div>
     </div>
     );
 };

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,12 +1,43 @@
 // src/components/Settings/Settings.js
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./Settings.css";
 import Modal from "./Modal";
 import UpdatePassword from "./UpdatePassword";
+import { auth, db } from "../../configuration";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
 
 const Settings = () => {
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalTitle, setModalTitle] = useState("");
+  const [placeholder, setPlaceholder] = useState("");
+  const [currentField, setCurrentField] = useState("");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  //const [password, setPassword] = useState("********");
+
+  //load current username and email from firestore
+  useEffect(() => {
+    const loadUserData = async () => {
+      try {
+        const userDoc = doc(db, "users", auth.currentUser.uid);
+        const userData = await getDoc(userDoc);
+
+        if (userData.exists()) {
+          setUsername(userData.data().username || "DefaultUsername");
+          setEmail(userData.data().email || "user@example.com");
+        }
+      } catch (error) {
+        console.error("Error loading user data:", error);
+      }
+    };
+
+    loadUserData();
+      
+      
+
+  }, []);
 
   const openPasswordModal = () => {
     setIsPasswordModalOpen(true);
@@ -16,17 +47,20 @@ const Settings = () => {
     setIsPasswordModalOpen(false);
   };
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [modalTitle, setModalTitle] = useState("");
-  const [placeholder, setPlaceholder] = useState("");
+  
 
   const openModal = (field) => {
-    setIsModalOpen(true);
     setModalTitle(`Update ${field}`);
     setPlaceholder(`Enter new ${field.toLowerCase()}`);
+    setCurrentField(field.toLowerCase());
+    setIsModalOpen(true);
   };
 
   const handleSave = (newValue) => {
+    if (currentField === "username") setUsername(newValue);
+    if (currentField === "email") setEmail(newValue);
+    //if (currentField === "password") setPassword(newValue);
+
     // Logic to update the username, email, or password with newValue
     console.log(`${modalTitle} updated to:`, newValue);
   };
@@ -38,9 +72,10 @@ const Settings = () => {
       <div className="settings-section">
         <h3>User Settings</h3>
         <ul className="settings-list">
-          <li onClick={() => openModal("Username")}>Username</li>
-          <li onClick={() => openModal("Email")}>Update Email</li>
-          {/* <li onClick={() => openModal("Password")}>Update Password</li> */}
+          <li onClick={() => openModal("Username")}>Username: {username}
+          </li>
+          <li onClick={() => openModal("Email")}>Email:{email}
+          </li>
           <li onClick={openPasswordModal}>Update Password</li>
           <li>Delete Data</li>
         </ul>
@@ -68,6 +103,7 @@ const Settings = () => {
           placeholder={placeholder}
           onClose={() => setIsModalOpen(false)}
           onSave={handleSave}
+          currentField={currentField}
         />
       )}
     </div>

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -72,11 +72,11 @@ const Settings = () => {
       <div className="settings-section">
         <h3>User Settings</h3>
         <ul className="settings-list">
-          <li onClick={() => openModal("Username")}>Username: {username}
+          <li onClick={() => openModal("Username")}>Update Username {username}
           </li>
-          <li onClick={() => openModal("Email")}>Email:{email}
+          <li onClick={() => openModal("Email")}>Update Email {email}
           </li>
-          <li onClick={openPasswordModal}>Update Password</li>
+          <li onClick={() => openModal("Password")}>Update Password</li>
           <li>Delete Data</li>
         </ul>
       </div>

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -72,9 +72,9 @@ const Settings = () => {
       <div className="settings-section">
         <h3>User Settings</h3>
         <ul className="settings-list">
-          <li onClick={() => openModal("Username")}>Update Username {username}
+          <li onClick={() => openModal("Username")}>Update Username: <strong>{username}</strong>
           </li>
-          <li onClick={() => openModal("Email")}>Update Email {email}
+          <li onClick={() => openModal("Email")}>Update Email: <strong>{email}</strong>
           </li>
           <li onClick={() => openModal("Password")}>Update Password</li>
           <li>Delete Data</li>

--- a/src/components/shared/Header.js
+++ b/src/components/shared/Header.js
@@ -69,6 +69,7 @@ const SideMenu = () => {
     signOut(auth)
       .then(() => {
         console.log("User signed out");
+        navigate("/");
       })
       .catch((error) => {
         console.error("Error signing out:", error);
@@ -76,7 +77,7 @@ const SideMenu = () => {
   };
 
   const handleLoginClick = () => {
-    navigate("/login");
+    navigate("/");
   };
 
   return (
@@ -113,7 +114,7 @@ const SideMenu = () => {
         >
           <List dense>
             {/* Applying bold typography using primaryTypographyProps */}
-            <ListItem button component={Link} to="/">
+            <ListItem button component={Link} to="/home">
               <ListItemText
                 primary="Home"
                 primaryTypographyProps={linkTextStyle}

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -10,14 +10,23 @@ import { getFirestore } from "firebase/firestore";
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 
 const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID,
-  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+  apiKey: "AIzaSyBwlwlbJaPZnbAJahzJixfDty3TllgDPUo",
+  authDomain: "pocket-chef-b12ca.firebaseapp.com",
+  databaseURL: "https://pocket-chef-b12ca-default-rtdb.firebaseio.com/",
+  projectId: "pocket-chef-b12ca",
+  storageBucket: "pocket-chef-b12ca.firebasestorage.app",
+  messagingSenderId: "360017427713",
+  appId: "1:360017427713:web:748b842639ffefd6bcaf00",
+  measurementId: "G-HGQF66LHMF"
+  
+  //apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  //authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  //databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
+  //projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  //storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  //messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  //appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  //measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
 // Initialize Firebase

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -10,23 +10,14 @@ import { getFirestore } from "firebase/firestore";
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 
 const firebaseConfig = {
-  apiKey: "AIzaSyBwlwlbJaPZnbAJahzJixfDty3TllgDPUo",
-  authDomain: "pocket-chef-b12ca.firebaseapp.com",
-  databaseURL: "https://pocket-chef-b12ca-default-rtdb.firebaseio.com/",
-  projectId: "pocket-chef-b12ca",
-  storageBucket: "pocket-chef-b12ca.firebasestorage.app",
-  messagingSenderId: "360017427713",
-  appId: "1:360017427713:web:748b842639ffefd6bcaf00",
-  measurementId: "G-HGQF66LHMF"
-  
-  //apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  //authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  //databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
-  //projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  //storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  //messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  //appId: process.env.REACT_APP_FIREBASE_APP_ID,
-  //measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.REACT_APP_FIREBASE_DATABASE_URL,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
 };
 
 // Initialize Firebase


### PR DESCRIPTION
update modal, authentication, settings, header, home, app.js
**Modal update:**
- The update option for username, email, and password works (the only problem is that to update the email the user needs to verify their email but that deals with Firestore configuration)
- UX now matches the same as the rest of the application
- passwords now showcase the specific requirements needed to update
settings:
- Some changes visually to showcase the current email, username

**Authentication:**
- make sure that the user will be displayed the password requirements and will be visually showcased which ones are needed for their password
- made some navigation changes so that when the user clicks "login" or "sign up" they will be sent to the home page

**header & app.js:**
- made changes to the navigation so that the user cannot get soft-locked in the application
- changed the order and made it so that when the user starts the application, it will start them off at the authentication step of signing up or logging in
